### PR TITLE
Add Quick View dashboard

### DIFF
--- a/game/managers/view_manager.py
+++ b/game/managers/view_manager.py
@@ -1,0 +1,17 @@
+class ViewManager:
+    def __init__(self):
+        self.subscribers = {}
+        self.active_view = None
+        self.active_callback = None
+    def subscribe(self, attribute, callback, view_name):
+        if attribute not in self.subscribers:
+            self.subscribers[attribute] = {}
+        self.subscribers[attribute][view_name] = callback
+    def set_active_view(self, view_name, callback):
+        self.active_view = view_name
+        self.active_callback = callback
+    def notify(self, attribute):
+        if attribute in self.subscribers and self.active_view in self.subscribers[attribute]:
+            self.subscribers[attribute][self.active_view]()
+        elif self.active_callback:
+            self.active_callback()

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -136,6 +136,10 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
     def travel_to_location(self, location_name):
         location_manager = LocationManager()
         self.current_location = location_manager.get_location_by_name(location_name)
+        self.view_manager.notify('location')
+        
+        self.log_event(f'You traveled to {self.current_location.name}')
+        self.view_manager.notify('event_log')
 
     def get_current_location(self):
         return self.current_location
@@ -160,6 +164,9 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
             new_location = location_manager.get_location_by_coordinates(new_coordinates)
             if new_location:
                 self.current_location = new_location
+                self.log_event(f'You moved {direction_to_move.name} towards {self.current_location.name}')
+                self.view_manager.notify('location')
+                self.view_manager.notify('event_log')
         self.render_player_info()
 
     def can_visit_shops(self):

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -149,6 +149,7 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
         self.ui_manager.update_game_content(description)
     
     def show_map(self):
+        self.view_manager.set_active_view('show_map', self.show_map)
         location_manager = LocationManager()
         map = location_manager.generate_map()
         self.ui_manager.update_game_content(map)

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -141,9 +141,10 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
 
     def search_current_location(self):
         output, summary = self.current_location.search() # type: ignore
+        # Set the active view to the search_current_location view and update the game content
+        self.view_manager.set_active_view('search_current_location', lambda: self.ui_manager.update_game_content(output))
         if summary:
             self.log_event(summary)
-        self.ui_manager.update_game_content(output)
         self.view_manager.notify('event_log')
     
     def show_map(self):

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -14,37 +14,20 @@ from game.models.skills.profession_registry import ProfessionRegistry
 from rich.table import Table
 from rich.text import Text
 from rich.panel import Panel
+from game.managers.view_manager import ViewManager
 
 class Player(Character, HasPersistence, HealthBar, HasExperience):
-    class ViewManager:
-        def __init__(self):
-            self.subscribers = {}
-            self.active_view = None
-            self.active_callback = None
-        def subscribe(self, attribute, callback, view_name):
-            if attribute not in self.subscribers:
-                self.subscribers[attribute] = {}
-            self.subscribers[attribute][view_name] = callback
-        def set_active_view(self, view_name, callback):
-            self.active_view = view_name
-            self.active_callback = callback
-        def notify(self, attribute):
-            if attribute in self.subscribers and self.active_view in self.subscribers[attribute]:
-                self.subscribers[attribute][self.active_view]()
-            elif self.active_callback:
-                self.active_callback()
-
     def __init__(self):
         HasPersistence.__init__(self, "./game/data/player.yaml")
 
         self.inventory = Inventory()
         self.ui_manager = UIManager()
+        self.view_manager = ViewManager()
         self.current_location = LocationManager().get_location_by_id(1)  # Assuming starting location is ID 1
         self.command_registry = CommandRegistry()
         self.profession_registry = ProfessionRegistry(self)
-        self.event_log = []  # Add a simple event log
-        self.view_manager = self.ViewManager()
-        # Subscribe views to attributes, but only one will be active at a time
+        
+        self.event_log = []
         self.view_manager.subscribe('location', self.show_map, 'show_map')
         self.view_manager.subscribe('event_log', self.event_log_view, 'event_log_view')
 

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -233,7 +233,6 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
         table = Table.grid(expand=True)
         table.add_row(Panel(events_text, title="Recent Events", border_style="magenta"))
         self.ui_manager.update_game_content(table)
-        self.ui_manager.render()
 
     def log_event(self, message: str):
         self.event_log.append(message)

--- a/game/models/characters/player.py
+++ b/game/models/characters/player.py
@@ -145,8 +145,11 @@ class Player(Character, HasPersistence, HealthBar, HasExperience):
         return self.current_location
 
     def search_current_location(self):
-        description = self.current_location.search() # type: ignore
-        self.ui_manager.update_game_content(description)
+        output, summary = self.current_location.search() # type: ignore
+        if summary:
+            self.log_event(summary)
+        self.ui_manager.update_game_content(output)
+        self.view_manager.notify('event_log')
     
     def show_map(self):
         self.view_manager.set_active_view('show_map', self.show_map)

--- a/game/models/locations/base_location.py
+++ b/game/models/locations/base_location.py
@@ -36,9 +36,7 @@ class BaseLocation():
     def __str__(self):
         return f"{self.name} ({self.coordinates}): {self.description}"
     
-    def search(self) -> Text:
-        """
-        Abstract method to be implemented by subclasses.
-        This method should define what happens when a player searches the location.
-        """
-        pass
+    def search(self):
+        output = Text(f'You search {self.name} but find nothing of interest.', style="dim")
+        summary = f'You searched {self.name} but found nothing of interest.'
+        return output, summary

--- a/game/models/locations/forest.py
+++ b/game/models/locations/forest.py
@@ -28,13 +28,16 @@ class Forest(BaseLocation):
             "\n\n",
             "You search the forest...",
         )
+        summary = f'You searched {self.name}'
         if self.enemies:
             output.append("\nYou encounter some enemies!")
             for enemy in self.enemies:
                 output.append(f"\n- {type(enemy).__name__}")
+            summary += f' and encountered {len(self.enemies)} enemies'
         else:
             output.append("\nYou find nothing of interest.")
-        return output
+            summary += ' but found nothing of interest'
+        return output, summary
 
     def get_first_enemy(self):
         if self.enemies:

--- a/game/models/locations/village.py
+++ b/game/models/locations/village.py
@@ -31,11 +31,13 @@ class Village(BaseLocation, HasShops):
         output.append(f"You are in {self.name}.\n", style="bold green")
         output.append(f"{self.coordinates[0]}, {self.coordinates[1]}\n", style="bold cyan")
         output.append(f"{self.description}\n")
+        summary = f'You searched {self.name}'
         if self.shops:
             output.append("You find some shops in the village:\n", style="bold green")
             for shop in self.shops:
                 output.append(f"- {shop.name}\n", style="bold blue")
+            summary += f' and found {len(self.shops)} shop(s)'
         else:
             output.append("There are no shops in this village.", style="bold red")
-
-        return output
+            summary += ' but found no shops'
+        return output, summary


### PR DESCRIPTION
This PR adds a new quick view dashboard, along with a few other supporting enhancements such as an event log and view manager to allow views to be updated when dependent properties are changed automatically using a lazy pub/sub-ish style implementation.

<img width="600" alt="Screenshot 2025-06-10 at 12 13 37 AM" src="https://github.com/user-attachments/assets/ea5be6e7-70d7-4171-a1fd-9505b153b648" />


<img width="600" alt="Screenshot 2025-06-10 at 12 14 25 AM" src="https://github.com/user-attachments/assets/70e90ca4-e2c2-4076-9f33-166d2113160f" />

I haven't updated everything to log events, only the ones shown in the screenshots, those can be added as part of this PR or separately, just wanted to get some feedback first.